### PR TITLE
Fix product ordering

### DIFF
--- a/backend/apps/products/views.py
+++ b/backend/apps/products/views.py
@@ -44,7 +44,6 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
             Product.objects.filter(is_active=True)
             .select_related("brand", "category")
             .prefetch_related("category__parent")
-            .order_by(self.ordering[0])
         )
 
     def get_serializer_class(self):


### PR DESCRIPTION
Исправление: Удаление избыточного упорядочивания в ProductViewSet

Метод `get_queryset` в `ProductViewSet` включал жестко закодированный вызов `.order_by()`, который переопределял `OrderingFilter`. Это мешало пользователям применять пользовательскую сортировку к списку товаров через API.

Этот фикс удаляет избыточный вызов `.order_by()`, позволяя `OrderingFilter` фреймворка Django REST обрабатывать все сортировки, как и предполагалось. Это восстанавливает возможность сортировки списка товаров по любому из полей, указанных в `ordering_fields`.