### PR TITLE
Format Python code with Black formatter

### DIFF
--- a/backend/apps/common/migrations/0009_add_newsletter_and_news_models.py
+++ b/backend/apps/common/migrations/0009_add_newsletter_and_news_models.py
@@ -7,6 +7,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     """Описывает создание News и Newsletter моделей."""
+
     dependencies = [
         ("common", "0008_alter_customersynclog_options_and_more"),
     ]
@@ -45,8 +46,7 @@ class Migration(migrations.Migration):
                     "excerpt",
                     models.TextField(
                         help_text=(
-                            "Краткое описание для главной страницы "
-                            "(до 500 символов)"
+                            "Краткое описание для главной страницы " "(до 500 символов)"
                         ),
                         max_length=500,
                         verbose_name="Краткое описание",
@@ -95,8 +95,7 @@ class Migration(migrations.Migration):
                         db_index=True,
                         default=False,
                         help_text=(
-                            "Флаг публикации (только опубликованные "
-                            "видны на сайте)"
+                            "Флаг публикации (только опубликованные " "видны на сайте)"
                         ),
                         verbose_name="Опубликована",
                     ),
@@ -227,9 +226,7 @@ class Migration(migrations.Migration):
                     models.CheckConstraint(
                         check=(
                             models.Q(is_active=True, unsubscribed_at__isnull=True)
-                            | models.Q(
-                                is_active=False, unsubscribed_at__isnull=False
-                            )
+                            | models.Q(is_active=False, unsubscribed_at__isnull=False)
                         ),
                         name="newsletter_active_consistency",
                     )

--- a/backend/apps/common/tests/test_news.py
+++ b/backend/apps/common/tests/test_news.py
@@ -68,9 +68,7 @@ class TestNewsListEndpoint:
         assert response.data["results"][1]["title"] == "Новость 2"
         assert response.data["results"][2]["title"] == "Новость 3"
 
-    def test_get_news_list_with_pagination(
-        self, api_client: APIClient, published_news
-    ):
+    def test_get_news_list_with_pagination(self, api_client: APIClient, published_news):
         """Тест pagination для списка новостей."""
         url = reverse("common:news-list")
 


### PR DESCRIPTION
Исправлено форматирование согласно стандартам Black:
- Добавлена пустая строка после docstring в Migration классе
- Объединены строковые литералы в help_text полях
- Сокращены многострочные Q объекты до одной строки
- Исправлена сигнатура функции test_get_news_list_with_pagination