### PR TITLE
fix(e2e): исправление 24+ падающих E2E тестов

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -44,11 +44,11 @@ export default defineConfig({
     // Таймауты
     actionTimeout: 15000,
     // Увеличен timeout навигации из-за медленной компиляции Next.js в Docker
-    navigationTimeout: 60000,
+    navigationTimeout: 120000,
   },
 
   // Общий таймаут теста
-  timeout: 90000,
+  timeout: 150000,
 
   // Ожидание результата expect
   expect: {

--- a/frontend/tests/e2e/checkout.spec.ts
+++ b/frontend/tests/e2e/checkout.spec.ts
@@ -221,7 +221,7 @@ test.describe('Checkout Flow E2E Tests', () => {
     await expect(page.locator('input[name="firstName"]')).toHaveValue(testCheckoutData.firstName);
 
     // 5. Оформляем заказ (AC5)
-    await page.click('button[type="submit"]:has-text("Оформить заказ")');
+    await page.getByRole('button', { name: /оформить заказ/i }).click();
 
     // 6. Проверяем редирект на success страницу (AC6)
     await expect(page).toHaveURL(/\/checkout\/success\/\d+/);
@@ -340,7 +340,7 @@ test.describe('Checkout Form Validation E2E Tests', () => {
     await expect(page.locator('h2:has-text("Контактные данные")')).toBeVisible();
 
     // Пытаемся отправить пустую форму (клик по кнопке submit)
-    await page.click('button[type="submit"]:has-text("Оформить заказ")');
+    await page.getByRole('button', { name: /оформить заказ/i }).click();
 
     // Проверяем появление ошибок валидации
     // Email обязателен
@@ -364,7 +364,7 @@ test.describe('Checkout Form Validation E2E Tests', () => {
     await page.fill('input[name="phone"]', testCheckoutData.phone); // blur для триггера валидации
 
     // Проверяем ошибку формата email
-    await expect(page.locator('text=Некорректный формат email')).toBeVisible();
+    await expect(page.locator('text=Некорректный формат email').first()).toBeVisible();
 
     // Исправляем email
     await page.fill('input[name="email"]', 'valid@example.com');
@@ -385,7 +385,7 @@ test.describe('Checkout Form Validation E2E Tests', () => {
     await page.fill('input[name="email"]', testCheckoutData.email); // blur
 
     // Проверяем ошибку формата
-    await expect(page.locator('text=Формат: +7XXXXXXXXXX')).toBeVisible();
+    await expect(page.locator('text=Формат: +7XXXXXXXXXX').first()).toBeVisible();
 
     // Исправляем телефон
     await page.fill('input[name="phone"]', '+79001234567');
@@ -406,7 +406,7 @@ test.describe('Checkout Form Validation E2E Tests', () => {
     await page.fill('input[name="email"]', testCheckoutData.email); // blur
 
     // Проверяем ошибку
-    await expect(page.locator('text=6 цифр')).toBeVisible();
+    await expect(page.locator('text=6 цифр').first()).toBeVisible();
 
     // Исправляем индекс
     await page.fill('input[name="postalCode"]', '123456');
@@ -450,7 +450,7 @@ test.describe('Checkout Form Validation E2E Tests', () => {
     await fillCheckoutForm(page, testCheckoutData);
 
     // Пытаемся отправить форму
-    await page.click('button[type="submit"]:has-text("Оформить заказ")');
+    await page.getByRole('button', { name: /оформить заказ/i }).click();
 
     // Проверяем ошибку выбора способа доставки
     await expect(page.locator('text=Выберите способ доставки')).toBeVisible();
@@ -574,7 +574,7 @@ test.describe('Checkout Error Handling E2E Tests', () => {
     await page.click('input[value="courier"]');
 
     // Отправляем форму
-    await page.click('button[type="submit"]:has-text("Оформить заказ")');
+    await page.getByRole('button', { name: /оформить заказ/i }).click();
 
     // Проверяем отображение ошибки
     await expect(page.locator('text=Ошибка').first()).toBeVisible({ timeout: 10000 });
@@ -611,7 +611,7 @@ test.describe('Checkout Error Handling E2E Tests', () => {
     await page.click('input[value="courier"]');
 
     // Отправляем форму
-    await page.click('button[type="submit"]:has-text("Оформить заказ")');
+    await page.getByRole('button', { name: /оформить заказ/i }).click();
 
     // Ожидаем появления ошибки (общей или конкретной)
     await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 10000 });
@@ -641,7 +641,7 @@ test.describe('Checkout Error Handling E2E Tests', () => {
     await page.click('input[value="courier"]');
 
     // Отправляем форму
-    await page.click('button[type="submit"]:has-text("Оформить заказ")');
+    await page.getByRole('button', { name: /оформить заказ/i }).click();
 
     // Проверяем что страница не крашится и показывает ошибку
     await expect(page.locator('button[type="submit"]')).toBeVisible();

--- a/frontend/tests/e2e/profile/edit-profile.spec.ts
+++ b/frontend/tests/e2e/profile/edit-profile.spec.ts
@@ -36,7 +36,9 @@ test.describe('Profile Page - Edit Profile Flow', () => {
       await page.goto('/profile');
 
       // ASSERT
-      await expect(page).toHaveURL(/\/login\?next=\/profile/);
+      const url = new URL(page.url());
+      expect(url.pathname).toBe('/login');
+      expect(url.searchParams.get('next')).toBe('/profile');
     });
 
     test('allows authenticated users to access profile page', async ({ page }) => {
@@ -301,10 +303,10 @@ test.describe('Profile Page - Edit Profile Flow', () => {
 
       // ASSERT
       await expect(page.locator('text=Личный кабинет')).toBeVisible();
-      await expect(page.locator('a[href="/profile"]').first()).toBeVisible();
-      await expect(page.locator('a[href="/profile/orders"]').first()).toBeVisible();
-      await expect(page.locator('a[href="/profile/addresses"]').first()).toBeVisible();
-      await expect(page.locator('a[href="/profile/favorites"]').first()).toBeVisible();
+      await expect(page.locator('aside a[href="/profile"]')).toBeVisible();
+      await expect(page.locator('aside a[href="/profile/orders"]')).toBeVisible();
+      await expect(page.locator('aside a[href="/profile/addresses"]')).toBeVisible();
+      await expect(page.locator('aside a[href="/profile/favorites"]')).toBeVisible();
     });
 
     test('displays tab navigation on mobile', async ({ page }) => {

--- a/frontend/tests/e2e/search-history.spec.ts
+++ b/frontend/tests/e2e/search-history.spec.ts
@@ -183,7 +183,7 @@ test.describe('Search History Flow E2E Tests', () => {
     const searchField = page.locator('[data-testid="search-field"]').first();
     await expect(searchField).toBeVisible();
 
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     // Ждём появления истории
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
@@ -202,7 +202,7 @@ test.describe('Search History Flow E2E Tests', () => {
     await page.goto('/catalog');
 
     const searchField = page.locator('[data-testid="search-field"]').first();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     // Ждём появления истории
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
@@ -223,7 +223,7 @@ test.describe('Search History Flow E2E Tests', () => {
     await page.goto('/catalog');
 
     const searchField = page.locator('[data-testid="search-field"]').first();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     // Ждём появления истории
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
@@ -247,7 +247,7 @@ test.describe('Search History Flow E2E Tests', () => {
     await page.goto('/catalog');
 
     const searchField = page.locator('[data-testid="search-field"]').first();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     // Ждём появления истории
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
@@ -274,7 +274,7 @@ test.describe('Search History Flow E2E Tests', () => {
     await page.goto('/catalog');
 
     const searchField = page.locator('[data-testid="search-field"]').first();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     // Ждём появления истории
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
@@ -309,7 +309,9 @@ test.describe('Search History Flow E2E Tests', () => {
     await searchField.press('Enter');
 
     // Проверяем, что URL изменился
-    await expect(page).toHaveURL(/\/search\?q=тренажёр/);
+    const url = new URL(page.url());
+    expect(url.pathname).toBe('/search');
+    expect(url.searchParams.get('q')).toBe('тренажёр');
 
     // "Перезагружаем" страницу (симуляция новой сессии)
     await page.goto('/catalog');
@@ -364,7 +366,7 @@ test.describe('Search History Accessibility Tests', () => {
 
     const searchField = page.locator('[data-testid="search-field"]').first();
     await expect(searchField).toBeVisible();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     // Ждём появления истории
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
@@ -384,7 +386,7 @@ test.describe('Search History Accessibility Tests', () => {
     await page.goto('/catalog');
 
     const searchField = page.locator('[data-testid="search-field"]').first();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
 
@@ -405,7 +407,7 @@ test.describe('Search History Accessibility Tests', () => {
     await page.goto('/catalog');
 
     const searchField = page.locator('[data-testid="search-field"]').first();
-    await searchField.focus();
+    await searchField.locator('input').focus();
 
     await expect(page.locator('[data-testid="search-history"]')).toBeVisible({ timeout: 5000 });
 


### PR DESCRIPTION
Исправлены критичные проблемы E2E тестов, выявленные в предыдущей сессии. Ожидаемое увеличение успешности с 13/39 (33%) до 35-39/39 (90-100%).

## Исправления по приоритету:

### 🟢 Этап 1: Быстрые победы (5 тестов)
✅ Проблема #2: Strict mode violations в checkout.spec.ts
  - Добавлен .first() к селекторам сообщений об ошибках
  - Файлы: checkout.spec.ts:367,388,409

✅ Проблема #5: URL encoding кириллицы в search-history.spec.ts
  - Заменён regex проверки URL на корректную проверку через URL API
  - Файл: search-history.spec.ts:312-314

✅ Проблема #6: Redirect URL encoding в edit-profile.spec.ts
  - Заменён regex на проверку через URL API для параметра next
  - Файл: edit-profile.spec.ts:39-41

### 🟡 Этап 2: Средняя сложность (12 тестов)
✅ Проблема #7: Desktop navigation селектор
  - Исправлены селекторы для поиска навигации в <aside>
  - Файл: edit-profile.spec.ts:306-309

✅ Проблема #3: Кнопка "Оформить заказ" не найдена (5-6 тестов)
  - Заменён :has-text() селектор на getByRole()
  - Использован более надёжный Playwright API
  - Файл: checkout.spec.ts (6 мест)

✅ Проблема #1: Медленная компиляция checkout страницы (6 тестов)
  - Увеличен navigationTimeout: 60s → 120s
  - Увеличен общий timeout теста: 90s → 150s
  - Файл: playwright.config.ts:47,51

### 🔴 Этап 3: Сложная диагностика (7-8 тестов)
✅ Проблема #4: SearchHistory не появляется при фокусе
  - КОРНЕВАЯ ПРИЧИНА: фокус на <div> вместо <input>
  - data-testid="search-field" указывает на контейнер
  - Исправлено: searchField.focus() → searchField.locator('input').focus()
  - Файл: search-history.spec.ts (8 мест)

## Технические детали:

### Проблема с фокусом (самая критичная)
```typescript
// БЫЛО (не работало):
const searchField = page.locator('[data-testid="search-field"]').first();
await searchField.focus(); // фокус на <div>, не триггерит onFocus

// СТАЛО:
await searchField.locator('input').focus(); // фокус на <input>, триггерит onFocus
```

SearchHistory показывается только при:
1. isFocused === true (onFocus на input)
2. query.trim().length === 0
3. history.length > 0

### URL encoding кириллицы
```typescript
// БЫЛО:
await expect(page).toHaveURL(/\/search\?q=тренажёр/);

// СТАЛО:
const url = new URL(page.url());
expect(url.pathname).toBe('/search');
expect(url.searchParams.get('q')).toBe('тренажёр');
```

## Ожидаемые результаты:
- Исправлено: ~24+ теста
- До: 13/39 проходят (33%)
- После: 35-39/39 проходят (90-100%)

## Тестирование:
```bash
cd frontend && npm run test:e2e
# ИЛИ конкретные файлы:
npx playwright test checkout.spec.ts
npx playwright test search-history.spec.ts
npx playwright test edit-profile.spec.ts
```

Story: E2E Test Fixes
Files: frontend/playwright.config.ts, frontend/tests/e2e/*.spec.ts