### PR TITLE
feat: улучшение блока адреса доставки в чекауте — автозаполнение, сел…

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -12,3 +12,9 @@
 - Двойной submit при `isSubmitting: true` не защищён в orderStore — pre-existing.
 - Validation coverage PromoCodeInput деградирована (удалены тесты Min Order Amount / Apply Error) — восстановить при реализации серверной promo-системы.
 - error path тесты в `orderStore.test.ts` помечены `.skip` — pre-existing, не вызвано текущим diff.
+
+## Deferred from: checkout-address-ux-improvements review (2026-04-29)
+
+- `orderId === 0` или `orderId === ""` (falsy) в CheckoutForm.onSubmit — нет редиректа на success, хотя заказ создан. Pre-existing, не вызвано текущим diff. Риск минимален (PostgreSQL serial начинает с 1), но стоит добавить guard `if (orderId != null && orderId !== '')` в будущем рефакторинге. [frontend/src/components/checkout/CheckoutForm.tsx:253]
+- `orderStore.currentOrder` может содержать stale id после failed `createOrder` — при повторном submit возможен ложный редирект на старый заказ. Pre-existing, зависит от реализации orderStore. Рассмотреть сброс `currentOrder` при ошибке в orderStore. [frontend/src/stores/orderStore.ts]
+- Контактные поля (firstName, lastName, phone) перезаписываются при автозаполнении из Address.full_name — если адрес оформлен на другого получателя (B2B склад), имя подменяется. Спека намеренно включает контактные поля в маппинг (Address хранит full_name+phone). Если потребуется разделение «контакт заказчика» vs «получатель» — отдельная задача. [frontend/src/utils/checkout/addressMapping.ts]

--- a/_bmad-output/implementation-artifacts/spec-checkout-address-ux-improvements.md
+++ b/_bmad-output/implementation-artifacts/spec-checkout-address-ux-improvements.md
@@ -1,0 +1,190 @@
+---
+title: "Улучшение блока адреса доставки в форме чекаута"
+type: "feature"
+created: "2026-04-29"
+status: "done"
+baseline_commit: "96de87521c423f4b27e141e8ace363c75dfc23f6"
+context:
+  - "{project-root}/_bmad-output/planning-artifacts/checkout-address-ux.md"
+  - "{project-root}/CLAUDE.md"
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** В блоке адреса доставки чекаута авторизованным пользователям не подставляется их сохранённый адрес. Текущий код читает `user.addresses[0]`, но `/api/v1/users/me/` не возвращает массив адресов — автозаполнение фактически мёртвое. Нет выбора между сохранёнными адресами и нет способа сохранить новый адрес из чекаута в профиль.
+
+**Approach:** При монтировании `CheckoutForm` авторизованного пользователя загружать его адреса типа `shipping` через `addressService.getAddresses()`. Подставлять адрес с `is_default=true`; если адресов больше одного — показать селектор (карточки) над полями; после ручного редактирования предлагать чекбокс «Запомнить этот адрес в профиле» — при согласии после успешного создания заказа делать `POST /api/v1/users/addresses/` (с `is_default=true`, если у юзера ещё нет адресов).
+
+## Boundaries & Constraints
+
+**Always:**
+- Использовать существующие `addressService` (`frontend/src/services/addressService.ts`) и тип `Address` (`frontend/src/types/address.ts`). Не дублировать сервис, не менять контракты API.
+- Поля API (`building`, `building_section`, `postal_code`, `full_name`) маппить на поля формы (`house`, `buildingSection`, `postalCode`, `firstName`+`lastName`) через единый helper. Никаких ad-hoc маппингов в компонентах.
+- Фильтрация `address_type === "shipping"` — на фронте (API не поддерживает query-фильтр).
+- Сохранение адреса в профиль не должно блокировать UX заказа: заказ уже создан — ошибка POST `/users/addresses/` показывается тостом, не откатывает заказ.
+- Tailwind CSS, react-hook-form через существующий `form` instance, валидация без изменений `checkoutSchema`.
+
+**Ask First:**
+- Если потребуется менять тип `User` или `checkoutSchema` (поле, валидация). По умолчанию — не менять.
+- Если рендер UI селектора потребует нового UI-примитива вне существующих (по умолчанию — кастомные карточки на Tailwind, как в `AddressList`).
+
+**Never:**
+- Не реализовывать редактирование/удаление адресов из чекаута (это раздел `/profile/addresses`).
+- Не интегрировать DaData/внешний автокомплит.
+- Не вызывать `getAddresses()` для гостей (неавторизованных).
+- Не вызывать `getAddresses()` повторно после успешного `POST` на финальном шаге — заказ уже создан, обновление списка избыточно.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|---------------|----------------------------|----------------|
+| Гость | `isAuthenticated=false` | Селектор не рендерится; чекбокс «запомнить» скрыт; форма пустая | N/A |
+| Авторизован, адресов нет | `getAddresses()` → `[]` | Селектор скрыт; после ввода адреса показывается чекбокс «Запомнить». Если выбран — POST с `is_default=true` | API упал — тост «не удалось загрузить адреса», форма остаётся пустой |
+| Авторизован, 1 shipping-адрес | `[a1]` | Поля автозаполнены из `a1`; селектор скрыт; после редактирования чекбокс «Запомнить» (POST `is_default=false`) | Маппинг ошибся — fallback на пустые поля |
+| Авторизован, 2+ shipping, есть `is_default` | `[a1{default}, a2, a3]` | Поля автозаполнены `is_default`-адресом; селектор показывает все 3 карточки, дефолт выделен | — |
+| Авторизован, 2+ shipping, нет `is_default` | `[a1, a2]` | Поля автозаполнены первым из массива (бэк сортирует `-created_at`); селектор показан | — |
+| Выбор другого адреса в селекторе | Клик по `a2` | Все поля формы перезаписываются данными `a2`; чекбокс «Запомнить» сбрасывается | — |
+| Ручное редактирование после автозаполнения | Юзер меняет любое поле | Показывается чекбокс «Запомнить этот адрес в профиле»; в селекторе снимается выделение | — |
+| Submit + чекбокс активен | Заказ создан, `saveAddress=true` | После `router.push(/checkout/success/...)` фоном `POST /users/addresses/` с маппингом полей | POST упал — тост-ошибка, заказ не откатывается |
+| Submit + чекбокс активен, но адрес идентичен выбранному из селектора | Юзер выбрал из селектора, ничего не менял | Чекбокс не показывается — нечего сохранять | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `frontend/src/components/checkout/CheckoutForm.tsx` — оркестрирует загрузку адресов, маппит выбранный/дефолтный адрес в `defaultValues`, прокидывает selector-state в `AddressSection`, после `createOrder` запускает фоновое сохранение адреса.
+- `frontend/src/components/checkout/AddressSection.tsx` — рендерит UI селектора (карточки) над существующими полями, чекбокс «Запомнить» под полями. Получает props: `addresses`, `selectedAddressId`, `onSelectAddress`, `showSaveCheckbox`, `saveAddress`, `onToggleSaveAddress`.
+- `frontend/src/components/checkout/AddressCardOption.tsx` — **новый**, маленький presentational компонент карточки адреса для селектора (имя получателя, `full_address`, бейдж «по умолчанию», radio-state). Не переиспользуем `business/AddressCard` — там есть кнопки edit/delete.
+- `frontend/src/utils/checkout/addressMapping.ts` — **новый** helper. Экспортирует `addressToFormValues(address: Address): Partial<CheckoutFormData>` и `formValuesToAddressPayload(data: CheckoutFormData): AddressFormData`. Содержит склейку `firstName + lastName ↔ full_name`.
+- `frontend/src/services/addressService.ts` — **используем как есть** (getAddresses, createAddress).
+- `frontend/src/types/address.ts` — **используем как есть** (тип `Address`, `AddressFormData`).
+- `frontend/src/stores/authStore.ts` — источник `user`, `isAuthenticated` через `authSelectors`.
+- `frontend/src/components/checkout/__tests__/AddressSection.test.tsx` — расширить: рендер селектора, переключение, чекбокс.
+- `frontend/src/components/checkout/__tests__/CheckoutForm.test.tsx` — расширить: моки `addressService.getAddresses`/`createAddress`, ветки edge-cases из матрицы.
+
+## Tasks & Acceptance
+
+**Execution:**
+
+- [x] `frontend/src/utils/checkout/addressMapping.ts` -- создать helper с двумя функциями (`addressToFormValues`, `formValuesToAddressPayload`) -- единая точка маппинга снимает риск рассинхронизации полей API ↔ формы.
+- [x] `frontend/src/components/checkout/AddressCardOption.tsx` -- создать карточку выбора (radio-style, отображает `full_name`, `full_address`, бейдж `is_default`) -- переиспользуемая presentational единица для селектора.
+- [x] `frontend/src/components/checkout/AddressSection.tsx` -- добавить рендер селектора (видим, если `addresses.length > 1`) и чекбокса «Запомнить» (видим по флагу из CheckoutForm); сохранить существующую разметку и тесты полей -- расширение без переломки.
+- [x] `frontend/src/components/checkout/CheckoutForm.tsx` -- (1) убрать использование `userWithAddresses.addresses[0]`; (2) добавить `useEffect` загрузки адресов через `addressService.getAddresses()` для авторизованного юзера, фильтр по `address_type==="shipping"`; (3) state: `addresses`, `selectedAddressId`, `saveAddress`; (4) подписка `form.watch` для определения «изменено ли после автозаполнения»; (5) после `await createOrder(data)` — если `saveAddress && currentOrder?.id` — fire-and-forget `addressService.createAddress(...)` с `is_default = addresses.length===0`; (6) тосты на ошибки сохранения адреса (использовать `sonner`, как в `AddressList`).
+- [x] `frontend/src/components/checkout/__tests__/AddressSection.test.tsx` -- добавить тесты: рендер селектора при `addresses.length>1`, скрытие при `<2`, переключение через клик, рендер чекбокса по флагу.
+- [x] `frontend/src/components/checkout/__tests__/CheckoutForm.test.tsx` -- добавить тесты для всех строк I/O Matrix: моки `getAddresses` (пустой/один/несколько), ошибка API, submit с/без чекбокса, проверка вызова `createAddress` с правильным payload и `is_default`.
+
+**Acceptance Criteria:**
+
+- Given авторизованный юзер с одним shipping-адресом и `is_default=true`, when открывает `/checkout`, then поля адреса заполнены данными этого адреса, селектор адресов не виден.
+- Given авторизованный юзер с тремя shipping-адресами (один `is_default`), when открывает `/checkout`, then над полями отображается селектор с тремя карточками, дефолтная выделена, поля автозаполнены из дефолтной.
+- Given юзер выбрал в селекторе другой адрес, when селектор перерисовался, then все поля формы перезаписались данными выбранного адреса и чекбокс «Запомнить» скрыт.
+- Given юзер вручную изменил `city` после автозаполнения, when поле потеряло фокус, then под полями появился чекбокс «Запомнить этот адрес в профиле» (по умолчанию выключен).
+- Given чекбокс «Запомнить» включён, у юзера 0 сохранённых адресов, when форма успешно отправлена и `currentOrder.id` доступен, then выполнен `POST /api/v1/users/addresses/` с `is_default=true` и корректным маппингом всех полей; ошибка вызова не блокирует переход на success-страницу.
+- Given гость на чекауте, when форма отрисована, then `addressService.getAddresses` не вызывается, селектор не рендерится, чекбокса «Запомнить» нет.
+- Given API адресов вернул 500, when CheckoutForm смонтировался, then показан тост-ошибка, форма пустая, юзер может заполнить вручную и оформить заказ.
+- Все существующие тесты `AddressSection.test.tsx` и `CheckoutForm.test.tsx` проходят без изменений ожидаемого поведения полей.
+
+## Spec Change Log
+
+### Loop 1 (2026-04-29) — adversarial + edge-case + acceptance review
+
+**Finding:** `splitFullName` падал на `null/undefined` в `full_name`; race: поздний resolve `getAddresses` перезаписывал введённые пользователем данные; при logout адреса «протекали» в следующую сессию; `shouldValidate:false` оставлял фантом-ошибки; `is_default` race при медленной загрузке; stale `showSaveCheckbox` в `onSubmit`; тест POST createAddress молча пропускал проверку.
+
+**Amended:**
+- `addressMapping.ts`: `splitFullName` — null-guard (`string | null | undefined`).
+- `CheckoutForm.tsx`:
+  - `addressesLoaded` state — защищает `is_default` от ложного `true` до резолва API.
+  - Race-guard в `getAddresses` useEffect — не перезаписывает поля, если юзер уже что-то ввёл.
+  - Reset addresses при logout (`if (!isAuthenticated) { setAddresses([]); ... }`).
+  - `form.clearErrors([...ADDRESS_FIELDS])` после `applyAddressToForm` — убирает фантомы.
+  - `onSubmit` пересчитывает dirty-vs-address по валидированному `data`, а не по stale `showSaveCheckbox`.
+  - Toast при ошибке `createAddress` убран (пользователь уже на success-странице — console.error достаточно).
+- `AddressCardOption.tsx`: `break-words` на `full_address`.
+- Тесты: добавлен mock `deliveryService`, rewrite POST test с полной формой + 3 новых edge-case теста.
+
+**KEEP (positive preservation):**
+- Единый `addressMapping.ts` как источник истины маппинга — не менять.
+- Fire-and-forget паттерн для `createAddress` (без await перед router.push) — сохранить.
+- `showSaveCheckbox` через `useMemo` + `form.watch` — архитектура верная, изменили только consumers.
+- `AddressCardOption` — presentational без edit/delete — не перегружать.
+
+## Design Notes
+
+**Маппинг полей** (источник истины — `addressMapping.ts`):
+
+```ts
+// Address (API) → CheckoutFormData
+{
+  city, street, postal_code → postalCode,
+  building → house,
+  building_section → buildingSection,
+  apartment,
+  full_name → firstName + lastName (split на первый пробел: "Иван Иванов" → ["Иван", "Иванов"])
+  phone
+}
+// CheckoutFormData → AddressFormData (POST payload)
+{
+  address_type: "shipping",
+  full_name: `${firstName} ${lastName}`.trim(),
+  phone, city, street,
+  building: house, building_section: buildingSection ?? "",
+  apartment: apartment ?? "",
+  postal_code: postalCode,
+  is_default: addresses.length === 0,
+}
+```
+
+**Детект «изменено вручную»:** хранить в state `lastAppliedAddressId` (id адреса, чьи данные сейчас в полях, или `null` если не из адреса). Подписаться на `form.watch` для адресных полей; если значение поля отличается от соответствующего в `addresses.find(a=>a.id===lastAppliedAddressId)` — выставить флаг `isManuallyEdited=true`. Чекбокс «Запомнить» рендерится только при `isAuthenticated && isManuallyEdited`.
+
+**UI селектора:** горизонтальный grid карточек (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3`), каждая — clickable card с border, выбранная — `border-blue-500 bg-blue-50`. Бейдж «По умолчанию» — `text-xs bg-blue-100 text-blue-700 rounded px-2 py-0.5`. Стилистика консистентна с `AddressCard` из профиля, но без кнопок edit/delete.
+
+**Fire-and-forget сохранение:** не `await` перед `router.push`. Вызвать `addressService.createAddress(payload).catch(err => toast.error(...))` параллельно с навигацией. Заказ уже создан — UX заказа не должен зависеть от сохранения адреса.
+
+## Verification
+
+**Commands:**
+
+- `cd frontend && npm run test -- src/components/checkout/__tests__/AddressSection.test.tsx` — все тесты зелёные, новые покрывают селектор и чекбокс.
+- `cd frontend && npm run test -- src/components/checkout/__tests__/CheckoutForm.test.tsx` — все тесты зелёные, покрыты строки I/O Matrix.
+- `cd frontend && npx tsc --noEmit` — без ошибок типов.
+- `cd frontend && npm run lint` — без новых предупреждений.
+
+**Manual checks:**
+
+- Залогиниться юзером с 0/1/3 shipping-адресами (создать через `/profile/addresses` если нужно), открыть `/checkout`, проверить визуально все ветки матрицы. Убедиться, что чекбокс появляется только после реального изменения поля. Submit-flow → проверить в DevTools Network, что `POST /users/addresses/` уходит после `POST /orders/` и не блокирует редирект.
+
+## Suggested Review Order
+
+**Entry point: orchestration and state management**
+
+- Core checkout form — loads addresses, manages selection/dirty/save state, fire-and-forget save
+  [`CheckoutForm.tsx:61`](../../../frontend/src/components/checkout/CheckoutForm.tsx#L61)
+
+- Address loading useEffect — race guard, auth reset, addressesLoaded flag
+  [`CheckoutForm.tsx:130`](../../../frontend/src/components/checkout/CheckoutForm.tsx#L130)
+
+- Submit handler — dirty recalc from validated `data`, shouldSaveAddress guard
+  [`CheckoutForm.tsx:224`](../../../frontend/src/components/checkout/CheckoutForm.tsx#L224)
+
+**Mapping layer (API ↔ form)**
+
+- Null-safe splitFullName, addressToFormValues, formValuesToAddressPayload, isFormDirtyVsAddress
+  [`addressMapping.ts:35`](../../../frontend/src/utils/checkout/addressMapping.ts#L35)
+
+**UI components**
+
+- Address section — selector grid, save checkbox, existing fields preserved
+  [`AddressSection.tsx:36`](../../../frontend/src/components/checkout/AddressSection.tsx#L36)
+
+- Radio-style card with break-words, is_default badge, Check icon
+  [`AddressCardOption.tsx:21`](../../../frontend/src/components/checkout/AddressCardOption.tsx#L21)
+
+**Tests**
+
+- 27 CheckoutForm tests — I/O Matrix, address loading, POST save, edge-cases
+  [`CheckoutForm.test.tsx:1`](../../../frontend/src/components/checkout/__tests__/CheckoutForm.test.tsx#L1)
+
+- 21 AddressSection tests — selector, checkbox, existing field tests preserved
+  [`AddressSection.test.tsx:1`](../../../frontend/src/components/checkout/__tests__/AddressSection.test.tsx#L1)

--- a/_bmad-output/planning-artifacts/checkout-address-ux.md
+++ b/_bmad-output/planning-artifacts/checkout-address-ux.md
@@ -1,0 +1,88 @@
+# Задача разработчику: улучшение блока адреса доставки в форме заказа
+
+**Дата:** 2026-04-29  
+**Приоритет:** средний  
+**Статус:** открыта
+
+---
+
+## Контекст
+
+В текущей реализации (`CheckoutForm` / `AddressSection`) адрес доставки заполняется вручную. При наличии авторизованного пользователя поля автозаполняются из `user.addresses[0]` — первого адреса в массиве, без учёта флага `is_default` и без возможности выбрать другой адрес. Нужно доработать этот блок в трёх направлениях.
+
+---
+
+## Требования
+
+### 1. Автозаполнение из адреса по умолчанию
+
+Если пользователь авторизован и у него есть сохранённые адреса — подставлять в поля формы адрес с флагом `is_default = true` и `address_type = "shipping"` (а не просто первый в массиве).
+
+Текущее поведение (исправить):
+```typescript
+city: user?.addresses?.[0]?.city || ""
+```
+Ожидаемое поведение:
+```typescript
+const defaultAddress = user?.addresses?.find(a => a.is_default && a.address_type === "shipping")
+city: defaultAddress?.city || ""
+```
+
+---
+
+### 2. Выбор адреса из сохранённых (если адресов больше одного)
+
+Если у авторизованного пользователя `addresses.length > 1` — показывать над полями формы UI для выбора адреса (выпадающий список или группу карточек). При выборе адреса — заполнять поля формы данными выбранного адреса.
+
+Если адрес только один или пользователь не авторизован — блок выбора не показывать, только поля ввода.
+
+Адреса получать через уже реализованный API:
+```
+GET /api/v1/users/addresses/
+```
+Фильтровать по `address_type = "shipping"`.
+
+---
+
+### 3. Предложение сохранить новый/изменённый адрес в профиль
+
+Если авторизованный пользователь вручную изменил поля адреса (или ввёл адрес впервые), — перед отправкой заказа показывать чекбокс или небольшой prompt:
+
+> «Запомнить этот адрес в профиле?»
+
+При согласии — после успешного создания заказа выполнять:
+```
+POST /api/v1/users/addresses/
+{ address_type: "shipping", city, street, house, apartment, postal_code, is_default: false }
+```
+
+Если у пользователя нет ни одного адреса — предлагать сохранить с `is_default: true`.
+
+---
+
+## Документы для реализации
+
+| Документ | Что нужно |
+|---|---|
+| `raw/docs/archive/v4/stories/epic-15/15.1.checkout-page-form.md` | Текущая реализация `AddressSection.tsx`, схема Zod, автозаполнение `defaultValues`, структура тестов |
+| `raw/docs/archive/v4/stories/epic-15/15.2.orders-api-integration.md` | Тип `CreateOrderPayload` — поле `delivery_address`, как адрес идёт в заказ |
+| `raw/docs/archive/v4/epics/epic-15/epic-15-checkout.md` | Общая архитектура checkout, упоминание `/profile/addresses` как опциональной интеграции |
+| `raw/docs/archive/releases/personal_cabinet_api_v1.0.md` | API адресов: `GET/POST /api/v1/users/addresses/`, структура ответа, флаг `is_default` |
+| `raw/docs/archive/v4/epics/epic-2/story-2.3-personal-cabinet-api-decisions.md` | Модель `Address`: поля `address_type`, `is_default`, логика автосброса флага default при сохранении нового |
+
+---
+
+## Затрагиваемые файлы
+
+- `frontend/src/components/checkout/AddressSection.tsx` — основные изменения UI
+- `frontend/src/components/checkout/CheckoutForm.tsx` — логика выбора/сохранения адреса
+- `frontend/src/schemas/checkoutSchema.ts` — схема без изменений, но учесть совместимость
+- `frontend/src/services/` — добавить или расширить сервис для `GET/POST /api/v1/users/addresses/`
+- `frontend/src/types/` — добавить тип `Address` с полями `id`, `address_type`, `is_default`, `city`, `street`, `house`, `apartment`, `postal_code`
+
+---
+
+## Не входит в задачу
+
+- Управление адресами в личном кабинете (редактирование/удаление) — это отдельный раздел профиля, уже реализован
+- Интеграция с внешними сервисами автокомплита адресов (DaData и пр.) — отдельная задача

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -5,3 +5,8 @@ coverage/
 .DS_Store
 test-results/
 playwright-report/
+**/__tests__/
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx

--- a/frontend/src/components/checkout/AddressCardOption.tsx
+++ b/frontend/src/components/checkout/AddressCardOption.tsx
@@ -44,10 +44,7 @@ export const AddressCardOption: React.FC<AddressCardOptionProps> = ({
       <div className="flex w-full items-start justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <MapPin
-            className={cn(
-              'h-4 w-4 flex-shrink-0',
-              selected ? 'text-blue-600' : 'text-gray-400'
-            )}
+            className={cn('h-4 w-4 flex-shrink-0', selected ? 'text-blue-600' : 'text-gray-400')}
             aria-hidden="true"
           />
           <span className="truncate text-sm font-semibold text-gray-900">
@@ -63,9 +60,7 @@ export const AddressCardOption: React.FC<AddressCardOptionProps> = ({
 
       <p className="break-words text-sm text-gray-600">{address.full_address}</p>
 
-      {address.phone && (
-        <p className="text-xs text-gray-500">{address.phone}</p>
-      )}
+      {address.phone && <p className="text-xs text-gray-500">{address.phone}</p>}
 
       {selected && (
         <span

--- a/frontend/src/components/checkout/AddressCardOption.tsx
+++ b/frontend/src/components/checkout/AddressCardOption.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+import { MapPin, Check } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import type { Address } from '@/types/address';
+
+export interface AddressCardOptionProps {
+  address: Address;
+  selected: boolean;
+  onSelect: (id: number) => void;
+}
+
+/**
+ * Карточка-опция выбора сохранённого адреса в селекторе чекаута.
+ *
+ * Отличается от business/AddressCard: нет кнопок edit/delete (управление
+ * адресами — на странице /profile/addresses), кликабельна целиком, имеет
+ * radio-state выделения.
+ */
+export const AddressCardOption: React.FC<AddressCardOptionProps> = ({
+  address,
+  selected,
+  onSelect,
+}) => {
+  const handleClick = () => onSelect(address.id);
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={handleClick}
+      data-testid="address-card-option"
+      data-selected={selected ? 'true' : 'false'}
+      className={cn(
+        'group relative flex w-full flex-col items-start gap-2 rounded-lg border bg-white p-4 text-left',
+        'transition-colors duration-150',
+        selected
+          ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500'
+          : 'border-gray-200 hover:border-blue-300'
+      )}
+    >
+      <div className="flex w-full items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <MapPin
+            className={cn(
+              'h-4 w-4 flex-shrink-0',
+              selected ? 'text-blue-600' : 'text-gray-400'
+            )}
+            aria-hidden="true"
+          />
+          <span className="truncate text-sm font-semibold text-gray-900">
+            {address.full_name || 'Без имени'}
+          </span>
+        </div>
+        {address.is_default && (
+          <span className="flex-shrink-0 rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+            По умолчанию
+          </span>
+        )}
+      </div>
+
+      <p className="break-words text-sm text-gray-600">{address.full_address}</p>
+
+      {address.phone && (
+        <p className="text-xs text-gray-500">{address.phone}</p>
+      )}
+
+      {selected && (
+        <span
+          className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-blue-500"
+          aria-hidden="true"
+        >
+          <Check className="h-3 w-3 text-white" strokeWidth={3} />
+        </span>
+      )}
+    </button>
+  );
+};
+
+AddressCardOption.displayName = 'AddressCardOption';
+
+export default AddressCardOption;

--- a/frontend/src/components/checkout/AddressSection.tsx
+++ b/frontend/src/components/checkout/AddressSection.tsx
@@ -2,38 +2,82 @@
 
 import { UseFormReturn } from 'react-hook-form';
 import { CheckoutFormData, CheckoutFormInput } from '@/schemas/checkoutSchema';
-import { Input } from '@/components/ui';
+import { Input, Checkbox } from '@/components/ui';
+import { AddressCardOption } from './AddressCardOption';
+import type { Address } from '@/types/address';
 
 export interface AddressSectionProps {
   form: UseFormReturn<CheckoutFormInput, unknown, CheckoutFormData>;
+  /** Список сохранённых shipping-адресов авторизованного пользователя */
+  addresses?: Address[];
+  /** ID выбранного адреса в селекторе (null — нет выбора, ввод вручную) */
+  selectedAddressId?: number | null;
+  /** Колбэк выбора адреса в селекторе */
+  onSelectAddress?: (id: number) => void;
+  /** Показывать ли чекбокс «запомнить адрес» */
+  showSaveCheckbox?: boolean;
+  /** Текущее состояние чекбокса «запомнить адрес» */
+  saveAddress?: boolean;
+  /** Колбэк переключения чекбокса */
+  onToggleSaveAddress?: (value: boolean) => void;
 }
 
 /**
- * Секция адреса доставки для формы checkout
- *
- * Story 15.1: Checkout страница и упрощённая форма
+ * Секция адреса доставки для формы checkout.
  *
  * Поля:
- * - Город (обязательно, минимум 2 символа)
- * - Улица (обязательно, минимум 3 символа)
- * - Дом (обязательно)
- * - Квартира (опционально)
- * - Индекс (обязательно, 6 цифр)
+ * - Город, Улица, Дом (обяз.), Корпус, Квартира, Индекс
  *
- * Автозаполнение:
- * - Для авторизованных пользователей данные берутся из user.addresses[0] (если есть)
+ * UX:
+ * - Если переданы 2+ сохранённых адреса — рендерим селектор-карточки над полями
+ * - Если showSaveCheckbox=true — рендерим чекбокс «запомнить адрес» под полями
+ * - Иначе — стандартная форма ввода
  */
-export function AddressSection({ form }: AddressSectionProps) {
+export function AddressSection({
+  form,
+  addresses,
+  selectedAddressId,
+  onSelectAddress,
+  showSaveCheckbox = false,
+  saveAddress = false,
+  onToggleSaveAddress,
+}: AddressSectionProps) {
   const {
     register,
     formState: { errors },
   } = form;
+
+  const showSelector = !!addresses && addresses.length > 1 && !!onSelectAddress;
 
   return (
     <section className="rounded-lg bg-white p-6 shadow-sm" aria-labelledby="address-section">
       <h2 id="address-section" className="mb-4 text-lg font-semibold text-gray-900">
         Адрес доставки
       </h2>
+
+      {/* Селектор сохранённых адресов */}
+      {showSelector && (
+        <div
+          className="mb-6"
+          role="radiogroup"
+          aria-label="Выберите сохранённый адрес"
+          data-testid="address-selector"
+        >
+          <p className="mb-2 text-sm font-medium text-gray-700">
+            Выберите сохранённый адрес
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {addresses!.map(addr => (
+              <AddressCardOption
+                key={addr.id}
+                address={addr}
+                selected={addr.id === selectedAddressId}
+                onSelect={onSelectAddress!}
+              />
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 gap-4">
         {/* Город */}
@@ -76,9 +120,8 @@ export function AddressSection({ form }: AddressSectionProps) {
           )}
         </div>
 
-        {/* Дом, Корпус и Квартира в одной строке на desktop */}
+        {/* Дом, Корпус и Квартира */}
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {/* Дом */}
           <div>
             <Input
               {...register('house')}
@@ -98,7 +141,6 @@ export function AddressSection({ form }: AddressSectionProps) {
             )}
           </div>
 
-          {/* Корпус */}
           <div>
             <Input
               {...register('buildingSection')}
@@ -116,7 +158,6 @@ export function AddressSection({ form }: AddressSectionProps) {
             )}
           </div>
 
-          {/* Квартира */}
           <div>
             <Input
               {...register('apartment')}
@@ -157,6 +198,17 @@ export function AddressSection({ form }: AddressSectionProps) {
             </p>
           )}
         </div>
+
+        {/* Чекбокс «запомнить адрес» */}
+        {showSaveCheckbox && (
+          <div className="pt-2" data-testid="save-address-checkbox-wrapper">
+            <Checkbox
+              label="Запомнить этот адрес в профиле"
+              checked={saveAddress}
+              onChange={e => onToggleSaveAddress?.(e.target.checked)}
+            />
+          </div>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/components/checkout/AddressSection.tsx
+++ b/frontend/src/components/checkout/AddressSection.tsx
@@ -63,9 +63,7 @@ export function AddressSection({
           aria-label="Выберите сохранённый адрес"
           data-testid="address-selector"
         >
-          <p className="mb-2 text-sm font-medium text-gray-700">
-            Выберите сохранённый адрес
-          </p>
+          <p className="mb-2 text-sm font-medium text-gray-700">Выберите сохранённый адрес</p>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {addresses!.map(addr => (
               <AddressCardOption

--- a/frontend/src/components/checkout/CheckoutForm.tsx
+++ b/frontend/src/components/checkout/CheckoutForm.tsx
@@ -191,8 +191,7 @@ export function CheckoutForm({ user }: CheckoutFormProps) {
     };
 
     // Если хотя бы одно адресное поле заполнено — есть что сохранять.
-    const hasAddressContent =
-      values.city || values.street || values.house || values.postalCode;
+    const hasAddressContent = values.city || values.street || values.house || values.postalCode;
     if (!hasAddressContent) return false;
 
     if (selectedAddressId !== null) {

--- a/frontend/src/components/checkout/CheckoutForm.tsx
+++ b/frontend/src/components/checkout/CheckoutForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { User } from '@/types/api';
 import {
   checkoutSchema,
@@ -13,6 +14,14 @@ import {
 } from '@/schemas/checkoutSchema';
 import { useOrderStore } from '@/stores/orderStore';
 import { useCartStore } from '@/stores/cartStore';
+import { addressService } from '@/services/addressService';
+import type { Address } from '@/types/address';
+import type { CheckoutAddressFields } from '@/utils/checkout/addressMapping';
+import {
+  addressToFormValues,
+  formValuesToAddressPayload,
+  isFormDirtyVsAddress,
+} from '@/utils/checkout/addressMapping';
 import { ContactSection } from './ContactSection';
 import { AddressSection } from './AddressSection';
 import { DeliveryOptions } from './DeliveryOptions';
@@ -20,81 +29,66 @@ import { OrderCommentSection } from './OrderCommentSection';
 import { OrderSummary } from './OrderSummary';
 import { InfoPanel } from '@/components/ui';
 
-/**
- * Расширенный тип User с полем addresses для автозаполнения
- * ВАЖНО: Базовый тип User из @/types/api не содержит поле addresses
- */
-interface UserAddress {
-  city: string;
-  street: string;
-  house: string;
-  apartment?: string;
-  postal_code: string;
-}
-
-interface UserWithAddresses extends User {
-  addresses?: UserAddress[];
-}
-
 export interface CheckoutFormProps {
   user: User | null;
 }
 
+const ADDRESS_FIELDS = [
+  'firstName',
+  'lastName',
+  'phone',
+  'city',
+  'street',
+  'house',
+  'buildingSection',
+  'apartment',
+  'postalCode',
+] as const;
+
 /**
- * Главная форма оформления заказа
+ * Главная форма оформления заказа.
  *
- * Story 15.1: Checkout страница и упрощённая форма
- * Story 15.2: Интеграция с Orders API
- *
- * Функциональность:
- * - React Hook Form для управления формой
- * - Zod валидация через zodResolver
- * - Автозаполнение данных для авторизованных пользователей
- * - Интеграция с orderStore для создания заказа
- * - Адаптивная вёрстка (mobile-first)
- * - Обработка ошибок валидации и отправки
- *
- * Секции:
- * 1. ContactSection - контактные данные
- * 2. AddressSection - адрес доставки
- * 3. DeliveryOptions - способ доставки (Story 15.3b)
- * 4. OrderCommentSection - комментарий к заказу
- * 5. OrderSummary - сводка заказа (sticky sidebar на desktop)
+ * Story 15.1 / 15.2 + spec checkout-address-ux-improvements:
+ * - React Hook Form + Zod валидация
+ * - Контактные данные автозаполняются из user
+ * - Shipping-адреса грузятся отдельным запросом GET /api/v1/users/addresses/
+ *   (не из user.addresses — сериализатор /users/me/ не возвращает массив)
+ * - Default-адрес автозаполняет поля; селектор — при 2+ адресах
+ * - После ручного редактирования предлагается сохранить адрес в профиль
+ *   (POST /api/v1/users/addresses/ выполняется fire-and-forget после успеха
+ *   создания заказа, чтобы не блокировать UX перехода на success-страницу)
  */
 export function CheckoutForm({ user }: CheckoutFormProps) {
   const router = useRouter();
 
-  // Order store для создания заказа
   const { createOrder, isSubmitting, error: orderError, clearOrder } = useOrderStore();
-
-  // Cart store для проверки пустой корзины
   const { items: cartItems } = useCartStore();
 
-  // Типизация user с addresses для автозаполнения
-  const userWithAddresses = user as UserWithAddresses | null;
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [selectedAddressId, setSelectedAddressId] = useState<number | null>(null);
+  const [saveAddress, setSaveAddress] = useState(false);
+  // True после первого resolve getAddresses. Защищает от race-условия:
+  // юзер успевает заполнить и засабмитить форму до того как API ответит,
+  // тогда `addresses.length === 0` ложно сигнализирует «новый адрес → is_default=true».
+  const [addressesLoaded, setAddressesLoaded] = useState(false);
 
-  // Инициализация React Hook Form с автозаполнением
+  const isAuthenticated = !!user;
+
   const form = useForm<CheckoutFormInput, unknown, CheckoutFormData>({
     resolver: zodResolver(checkoutSchema),
-    mode: 'onBlur', // Валидация при потере фокуса для лучшего UX
-    reValidateMode: 'onChange', // Ре-валидация при изменении
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
     defaultValues: {
-      // Контактные данные - автозаполнение из user
-      email: userWithAddresses?.email || defaultCheckoutFormValues.email,
-      phone: userWithAddresses?.phone || defaultCheckoutFormValues.phone,
-      firstName: userWithAddresses?.first_name || defaultCheckoutFormValues.firstName,
-      lastName: userWithAddresses?.last_name || defaultCheckoutFormValues.lastName,
-
-      // Адрес доставки - автозаполнение из user.addresses[0] (если есть)
-      city: userWithAddresses?.addresses?.[0]?.city || defaultCheckoutFormValues.city,
-      street: userWithAddresses?.addresses?.[0]?.street || defaultCheckoutFormValues.street,
-      house: userWithAddresses?.addresses?.[0]?.house || defaultCheckoutFormValues.house,
-      apartment:
-        userWithAddresses?.addresses?.[0]?.apartment || defaultCheckoutFormValues.apartment,
-      postalCode:
-        userWithAddresses?.addresses?.[0]?.postal_code || defaultCheckoutFormValues.postalCode,
-
-      // Остальные поля
+      email: user?.email || defaultCheckoutFormValues.email,
+      phone: user?.phone || defaultCheckoutFormValues.phone,
+      firstName: user?.first_name || defaultCheckoutFormValues.firstName,
+      lastName: user?.last_name || defaultCheckoutFormValues.lastName,
+      city: defaultCheckoutFormValues.city,
+      street: defaultCheckoutFormValues.street,
+      house: defaultCheckoutFormValues.house,
+      buildingSection: defaultCheckoutFormValues.buildingSection,
+      apartment: defaultCheckoutFormValues.apartment,
+      postalCode: defaultCheckoutFormValues.postalCode,
       deliveryMethod: defaultCheckoutFormValues.deliveryMethod,
       paymentMethod: defaultCheckoutFormValues.paymentMethod,
       comment: defaultCheckoutFormValues.comment,
@@ -106,28 +100,177 @@ export function CheckoutForm({ user }: CheckoutFormProps) {
     clearOrder();
   }, [clearOrder]);
 
-  /**
-   * Обработчик отправки формы
-   * Story 15.2: Интеграция с ordersService через orderStore
-   */
+  // Применяет данные адреса в поля формы и обнуляет флаг "запомнить".
+  const applyAddressToForm = useCallback(
+    (address: Address) => {
+      const values = addressToFormValues(address);
+      ADDRESS_FIELDS.forEach(field => {
+        form.setValue(field, values[field], {
+          shouldDirty: false,
+          shouldTouch: false,
+          shouldValidate: false,
+        });
+      });
+      // Очищаем фантом-ошибки, оставшиеся от ручных правок до автозаполнения.
+      form.clearErrors([...ADDRESS_FIELDS]);
+      setSelectedAddressId(address.id);
+      setSaveAddress(false);
+    },
+    [form]
+  );
+
+  // Загрузка сохранённых shipping-адресов авторизованного пользователя.
+  useEffect(() => {
+    if (!isAuthenticated) {
+      // Logout: гарантируем, что адреса от прежнего пользователя не «протекут».
+      setAddresses([]);
+      setSelectedAddressId(null);
+      setAddressesLoaded(false);
+      return;
+    }
+
+    let cancelled = false;
+    addressService
+      .getAddresses()
+      .then(list => {
+        if (cancelled) return;
+        const shipping = list.filter(a => a.address_type === 'shipping');
+        setAddresses(shipping);
+        setAddressesLoaded(true);
+        if (shipping.length === 0) return;
+
+        // Race-guard: если пользователь уже что-то ввёл в адресные поля до
+        // резолва промиса, не перезаписываем его данные.
+        const current = form.getValues(['city', 'street', 'house', 'postalCode']);
+        const userTyped = current.some(v => !!v && v.trim().length > 0);
+        if (userTyped) return;
+
+        const initial = shipping.find(a => a.is_default) ?? shipping[0];
+        applyAddressToForm(initial);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setAddressesLoaded(true);
+        // Деградация: форма остаётся доступной для ручного ввода.
+        console.error('Failed to load addresses:', err);
+        toast.error('Не удалось загрузить сохранённые адреса. Введите данные вручную.');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, applyAddressToForm, form]);
+
+  // Подписка на изменения адресных полей: вычисляем «правил ли пользователь вручную».
+  const watchedValues = form.watch(ADDRESS_FIELDS);
+
+  const showSaveCheckbox = useMemo(() => {
+    if (!isAuthenticated) return false;
+    const [
+      firstName,
+      lastName,
+      phone,
+      city,
+      street,
+      house,
+      buildingSection,
+      apartment,
+      postalCode,
+    ] = watchedValues;
+
+    const values = {
+      firstName: firstName ?? '',
+      lastName: lastName ?? '',
+      phone: phone ?? '',
+      city: city ?? '',
+      street: street ?? '',
+      house: house ?? '',
+      buildingSection: buildingSection ?? '',
+      apartment: apartment ?? '',
+      postalCode: postalCode ?? '',
+    };
+
+    // Если хотя бы одно адресное поле заполнено — есть что сохранять.
+    const hasAddressContent =
+      values.city || values.street || values.house || values.postalCode;
+    if (!hasAddressContent) return false;
+
+    if (selectedAddressId !== null) {
+      const selected = addresses.find(a => a.id === selectedAddressId);
+      if (!selected) return true;
+      return isFormDirtyVsAddress(values, selected);
+    }
+
+    // Адрес не выбран из списка — данные уникальны для текущего ввода.
+    return true;
+  }, [isAuthenticated, watchedValues, selectedAddressId, addresses]);
+
+  // Сбросить чекбокс, если редактирование «отменено» (поля совпали с выбранным адресом).
+  useEffect(() => {
+    if (!showSaveCheckbox && saveAddress) {
+      setSaveAddress(false);
+    }
+  }, [showSaveCheckbox, saveAddress]);
+
+  const handleSelectAddress = useCallback(
+    (id: number) => {
+      const target = addresses.find(a => a.id === id);
+      if (!target) return;
+      applyAddressToForm(target);
+    },
+    [addresses, applyAddressToForm]
+  );
+
   const onSubmit = async (data: CheckoutFormData) => {
     try {
-      // Проверка на пустую корзину (edge case)
       if (!cartItems || cartItems.length === 0) {
         useOrderStore.getState().setError('Корзина пуста, невозможно оформить заказ');
         return;
       }
 
-      // Создаём заказ через orderStore
+      // Снимаем dirty-флаг по уже валидированному `data` — `showSaveCheckbox`
+      // от watch-замыкания может отстать на один tick при быстром submit.
+      const dirtyVsSelected = ((): boolean => {
+        if (selectedAddressId === null) return true;
+        const selected = addresses.find(a => a.id === selectedAddressId);
+        if (!selected) return true;
+        const fieldsForCompare: CheckoutAddressFields = {
+          firstName: data.firstName,
+          lastName: data.lastName,
+          phone: data.phone,
+          city: data.city,
+          street: data.street,
+          house: data.house,
+          buildingSection: data.buildingSection ?? '',
+          apartment: data.apartment ?? '',
+          postalCode: data.postalCode,
+        };
+        return isFormDirtyVsAddress(fieldsForCompare, selected);
+      })();
+
+      const shouldSaveAddress =
+        isAuthenticated && saveAddress && dirtyVsSelected && addressesLoaded;
+
       await createOrder(data);
 
-      // При успехе - получаем ID заказа и перенаправляем на success
       const orderId = useOrderStore.getState().currentOrder?.id;
-      if (orderId) {
-        router.push(`/checkout/success/${orderId}`);
+      if (!orderId) return;
+
+      // Fire-and-forget сохранение адреса в профиль. Заказ уже создан —
+      // ошибка POST /users/addresses/ не должна блокировать редирект.
+      // Toast не показываем: пользователь уже на success-странице и
+      // ошибка о сохранении адреса там создаст путаницу.
+      if (shouldSaveAddress) {
+        const payload = formValuesToAddressPayload(data, {
+          isDefault: addresses.length === 0,
+        });
+        addressService.createAddress(payload).catch((err: Error) => {
+          console.error('Failed to save address:', err);
+        });
       }
+
+      router.push(`/checkout/success/${orderId}`);
     } catch (err) {
-      // Ошибка уже сохранена в orderStore.error
       console.error('Order creation failed:', err);
     }
   };
@@ -136,15 +279,11 @@ export function CheckoutForm({ user }: CheckoutFormProps) {
     formState: { errors },
   } = form;
 
-  // Общая ошибка формы (если есть ошибки валидации)
   const hasFormErrors = Object.keys(errors).length > 0;
-
-  // Проверка на пустую корзину
   const isCartEmpty = !cartItems || cartItems.length === 0;
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
-      {/* Ошибка пустой корзины */}
       {isCartEmpty && (
         <InfoPanel
           variant="warning"
@@ -154,7 +293,6 @@ export function CheckoutForm({ user }: CheckoutFormProps) {
         />
       )}
 
-      {/* Ошибка создания заказа от API */}
       {orderError && (
         <InfoPanel
           variant="error"
@@ -164,7 +302,6 @@ export function CheckoutForm({ user }: CheckoutFormProps) {
         />
       )}
 
-      {/* Общая ошибка валидации */}
       {hasFormErrors && (
         <InfoPanel
           variant="error"
@@ -174,24 +311,25 @@ export function CheckoutForm({ user }: CheckoutFormProps) {
         />
       )}
 
-      {/* Grid layout: форма + sidebar */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* Левая колонка: секции формы */}
         <div className="space-y-6 lg:col-span-2">
-          {/* 1. Контактные данные */}
           <ContactSection form={form} />
 
-          {/* 2. Адрес доставки */}
-          <AddressSection form={form} />
+          <AddressSection
+            form={form}
+            addresses={addresses}
+            selectedAddressId={selectedAddressId}
+            onSelectAddress={handleSelectAddress}
+            showSaveCheckbox={showSaveCheckbox}
+            saveAddress={saveAddress}
+            onToggleSaveAddress={setSaveAddress}
+          />
 
-          {/* 3. Способ доставки */}
           <DeliveryOptions form={form} />
 
-          {/* 4. Комментарий к заказу */}
           <OrderCommentSection form={form} />
         </div>
 
-        {/* Правая колонка: сводка заказа (sticky на desktop) */}
         <div className="lg:col-span-1">
           <OrderSummary
             isSubmitting={isSubmitting}

--- a/frontend/src/components/checkout/__tests__/AddressSection.test.tsx
+++ b/frontend/src/components/checkout/__tests__/AddressSection.test.tsx
@@ -1,12 +1,31 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { AddressSection } from '../AddressSection';
 import { checkoutSchema, CheckoutFormData, CheckoutFormInput } from '@/schemas/checkoutSchema';
+import type { Address } from '@/types/address';
+
+interface WrapperProps {
+  defaultValues?: Partial<CheckoutFormInput>;
+  addresses?: Address[];
+  selectedAddressId?: number | null;
+  onSelectAddress?: (id: number) => void;
+  showSaveCheckbox?: boolean;
+  saveAddress?: boolean;
+  onToggleSaveAddress?: (value: boolean) => void;
+}
 
 // Wrapper компонент для тестирования AddressSection
-function AddressSectionWrapper({ defaultValues }: { defaultValues?: Partial<CheckoutFormInput> }) {
+function AddressSectionWrapper({
+  defaultValues,
+  addresses,
+  selectedAddressId,
+  onSelectAddress,
+  showSaveCheckbox,
+  saveAddress,
+  onToggleSaveAddress,
+}: WrapperProps) {
   const form = useForm<CheckoutFormInput, unknown, CheckoutFormData>({
     resolver: zodResolver(checkoutSchema),
     mode: 'onBlur',
@@ -28,9 +47,37 @@ function AddressSectionWrapper({ defaultValues }: { defaultValues?: Partial<Chec
 
   return (
     <form>
-      <AddressSection form={form} />
+      <AddressSection
+        form={form}
+        addresses={addresses}
+        selectedAddressId={selectedAddressId}
+        onSelectAddress={onSelectAddress}
+        showSaveCheckbox={showSaveCheckbox}
+        saveAddress={saveAddress}
+        onToggleSaveAddress={onToggleSaveAddress}
+      />
     </form>
   );
+}
+
+function makeAddress(overrides: Partial<Address> = {}): Address {
+  return {
+    id: 1,
+    address_type: 'shipping',
+    full_name: 'Иван Иванов',
+    phone: '+79001234567',
+    city: 'Москва',
+    street: 'Ленина',
+    building: '10',
+    building_section: '',
+    apartment: '5',
+    postal_code: '123456',
+    is_default: false,
+    full_address: '123456, Москва, Ленина, 10, кв. 5',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
 }
 
 describe('AddressSection', () => {
@@ -179,6 +226,100 @@ describe('AddressSection', () => {
         const apartmentLabel = screen.getByText('Кв./офис');
         expect(apartmentLabel.closest('div')).not.toHaveClass('error');
       });
+    });
+  });
+
+  describe('Селектор сохранённых адресов', () => {
+    it('не отображается, если addresses не передан', () => {
+      render(<AddressSectionWrapper />);
+      expect(screen.queryByTestId('address-selector')).not.toBeInTheDocument();
+    });
+
+    it('не отображается при наличии одного адреса', () => {
+      render(
+        <AddressSectionWrapper
+          addresses={[makeAddress({ id: 1, is_default: true })]}
+          selectedAddressId={1}
+          onSelectAddress={() => {}}
+        />
+      );
+      expect(screen.queryByTestId('address-selector')).not.toBeInTheDocument();
+    });
+
+    it('отображает все адреса в виде карточек при addresses.length > 1', () => {
+      const addresses = [
+        makeAddress({ id: 1, is_default: true, full_name: 'Иван' }),
+        makeAddress({ id: 2, full_name: 'Петр' }),
+        makeAddress({ id: 3, full_name: 'Сидор' }),
+      ];
+      render(
+        <AddressSectionWrapper
+          addresses={addresses}
+          selectedAddressId={1}
+          onSelectAddress={() => {}}
+        />
+      );
+      const selector = screen.getByTestId('address-selector');
+      expect(selector).toBeInTheDocument();
+      const cards = screen.getAllByTestId('address-card-option');
+      expect(cards).toHaveLength(3);
+    });
+
+    it('помечает выбранную карточку через aria-checked', () => {
+      const addresses = [
+        makeAddress({ id: 1 }),
+        makeAddress({ id: 2 }),
+      ];
+      render(
+        <AddressSectionWrapper
+          addresses={addresses}
+          selectedAddressId={2}
+          onSelectAddress={() => {}}
+        />
+      );
+      const cards = screen.getAllByTestId('address-card-option');
+      expect(cards[0]).toHaveAttribute('aria-checked', 'false');
+      expect(cards[1]).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('вызывает onSelectAddress при клике по карточке', () => {
+      const onSelect = vi.fn();
+      const addresses = [makeAddress({ id: 1 }), makeAddress({ id: 2 })];
+      render(
+        <AddressSectionWrapper
+          addresses={addresses}
+          selectedAddressId={1}
+          onSelectAddress={onSelect}
+        />
+      );
+      const cards = screen.getAllByTestId('address-card-option');
+      fireEvent.click(cards[1]);
+      expect(onSelect).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe('Чекбокс «Запомнить адрес»', () => {
+    it('не отображается по умолчанию', () => {
+      render(<AddressSectionWrapper />);
+      expect(screen.queryByTestId('save-address-checkbox-wrapper')).not.toBeInTheDocument();
+    });
+
+    it('отображается при showSaveCheckbox=true', () => {
+      render(
+        <AddressSectionWrapper showSaveCheckbox saveAddress={false} onToggleSaveAddress={() => {}} />
+      );
+      expect(screen.getByTestId('save-address-checkbox-wrapper')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Запомнить этот адрес в профиле/)).toBeInTheDocument();
+    });
+
+    it('вызывает onToggleSaveAddress при клике', () => {
+      const onToggle = vi.fn();
+      render(
+        <AddressSectionWrapper showSaveCheckbox saveAddress={false} onToggleSaveAddress={onToggle} />
+      );
+      const checkbox = screen.getByLabelText(/Запомнить этот адрес в профиле/);
+      fireEvent.click(checkbox);
+      expect(onToggle).toHaveBeenCalledWith(true);
     });
   });
 

--- a/frontend/src/components/checkout/__tests__/CheckoutForm.test.tsx
+++ b/frontend/src/components/checkout/__tests__/CheckoutForm.test.tsx
@@ -1,24 +1,81 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { CheckoutForm } from '../CheckoutForm';
 import { useCartStore } from '@/stores/cartStore';
+import { addressService } from '@/services/addressService';
 import type { User } from '@/types/api';
+import type { Address } from '@/types/address';
 
 // Mock зависимостей
 vi.mock('@/stores/cartStore');
 vi.mock('@/stores/orderStore', () => ({
-  useOrderStore: vi.fn(() => ({
-    createOrder: vi.fn(),
-    isSubmitting: false,
-    error: null,
-    clearOrder: vi.fn(),
-  })),
+  useOrderStore: Object.assign(
+    vi.fn(() => ({
+      createOrder: vi.fn(),
+      isSubmitting: false,
+      error: null,
+      clearOrder: vi.fn(),
+    })),
+    {
+      getState: vi.fn(() => ({
+        currentOrder: null,
+        setError: vi.fn(),
+      })),
+    }
+  ),
 }));
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
 }));
+vi.mock('@/services/addressService', () => ({
+  addressService: {
+    getAddresses: vi.fn().mockResolvedValue([]),
+    createAddress: vi.fn().mockResolvedValue({}),
+    updateAddress: vi.fn(),
+    deleteAddress: vi.fn(),
+  },
+}));
+vi.mock('@/services/deliveryService', () => ({
+  default: {
+    getDeliveryMethods: vi.fn().mockResolvedValue([
+      {
+        id: 'pickup',
+        name: 'Самовывоз',
+        description: 'Из магазина',
+        icon: '🏪',
+        is_available: true,
+      },
+    ]),
+  },
+}));
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function makeAddress(overrides: Partial<Address> = {}): Address {
+  return {
+    id: 1,
+    address_type: 'shipping',
+    full_name: 'Иван Иванов',
+    phone: '+79001234567',
+    city: 'Москва',
+    street: 'Ленина',
+    building: '10',
+    building_section: '',
+    apartment: '5',
+    postal_code: '123456',
+    is_default: false,
+    full_address: '123456, Москва, Ленина, 10, кв. 5',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
 
 describe('CheckoutForm', () => {
   const mockUser: User = {
@@ -253,6 +310,303 @@ describe('CheckoutForm', () => {
       render(<CheckoutForm user={null} />);
 
       expect(screen.queryByTestId('price-before-discount')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Address loading и автозаполнение из API (spec checkout-address-ux)', () => {
+    it('гость — addressService.getAddresses не вызывается, селектора нет', async () => {
+      render(<CheckoutForm user={null} />);
+      await waitFor(() => {
+        expect(addressService.getAddresses).not.toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('address-selector')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('save-address-checkbox-wrapper')).not.toBeInTheDocument();
+    });
+
+    it('авторизован, 0 адресов — селектор не рендерится, форма пустая', async () => {
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+      render(<CheckoutForm user={mockUser} />);
+      await waitFor(() => {
+        expect(addressService.getAddresses).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.queryByTestId('address-selector')).not.toBeInTheDocument();
+      const cityInput = screen.getByLabelText('Город') as HTMLInputElement;
+      expect(cityInput.value).toBe('');
+    });
+
+    it('авторизован, 1 default-адрес — поля автозаполнены, селектор скрыт', async () => {
+      const addr = makeAddress({ id: 11, is_default: true, city: 'Казань' });
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce([addr]);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        const cityInput = screen.getByLabelText('Город') as HTMLInputElement;
+        expect(cityInput.value).toBe('Казань');
+      });
+      expect(screen.queryByTestId('address-selector')).not.toBeInTheDocument();
+    });
+
+    it('авторизован, 3 адреса с default — селектор показан, дефолт автозаполнен', async () => {
+      const list = [
+        makeAddress({ id: 1, city: 'Москва' }),
+        makeAddress({ id: 2, is_default: true, city: 'СПб', street: 'Невский', building: '1', postal_code: '190000' }),
+        makeAddress({ id: 3, city: 'Сочи' }),
+      ];
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce(list);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        const cityInput = screen.getByLabelText('Город') as HTMLInputElement;
+        expect(cityInput.value).toBe('СПб');
+      });
+
+      const cards = screen.getAllByTestId('address-card-option');
+      expect(cards).toHaveLength(3);
+      // Дефолт выделен
+      const selectedCard = cards.find(c => c.getAttribute('data-selected') === 'true');
+      expect(selectedCard).toBeDefined();
+    });
+
+    it('фильтрует адреса по address_type=shipping', async () => {
+      const list = [
+        makeAddress({ id: 1, address_type: 'shipping', is_default: true, city: 'Москва' }),
+        makeAddress({ id: 2, address_type: 'legal', city: 'Юр-адрес' }),
+      ];
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce(list);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        const cityInput = screen.getByLabelText('Город') as HTMLInputElement;
+        expect(cityInput.value).toBe('Москва');
+      });
+      // Селектор не появляется — после фильтра остался один shipping
+      expect(screen.queryByTestId('address-selector')).not.toBeInTheDocument();
+    });
+
+    it('выбор другого адреса в селекторе перезаписывает поля формы', async () => {
+      const list = [
+        makeAddress({ id: 1, is_default: true, city: 'Москва', street: 'Ленина', building: '10' }),
+        makeAddress({ id: 2, city: 'Сочи', street: 'Морская', building: '5', postal_code: '354000' }),
+      ];
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce(list);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        expect((screen.getByLabelText('Город') as HTMLInputElement).value).toBe('Москва');
+      });
+
+      const cards = screen.getAllByTestId('address-card-option');
+      // Карточки рендерятся в порядке массива addresses; вторая — Сочи
+      fireEvent.click(cards[1]);
+
+      await waitFor(() => {
+        expect((screen.getByLabelText('Город') as HTMLInputElement).value).toBe('Сочи');
+        expect((screen.getByLabelText('Дом') as HTMLInputElement).value).toBe('5');
+      });
+    });
+
+    it('ручное редактирование показывает чекбокс «Запомнить»', async () => {
+      const addr = makeAddress({ id: 1, is_default: true, city: 'Москва' });
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce([addr]);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        expect((screen.getByLabelText('Город') as HTMLInputElement).value).toBe('Москва');
+      });
+      expect(screen.queryByTestId('save-address-checkbox-wrapper')).not.toBeInTheDocument();
+
+      const cityInput = screen.getByLabelText('Город');
+      fireEvent.change(cityInput, { target: { value: 'Тверь' } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-address-checkbox-wrapper')).toBeInTheDocument();
+      });
+    });
+
+    it('ошибка getAddresses показывает toast, форма остаётся пустой', async () => {
+      const { toast } = await import('sonner');
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('500')
+      );
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalled();
+      });
+      const cityInput = screen.getByLabelText('Город') as HTMLInputElement;
+      expect(cityInput.value).toBe('');
+    });
+  });
+
+  describe('Address save после оформления заказа (spec checkout-address-ux)', () => {
+    async function fillFormAndSubmit({
+      withCheckbox,
+    }: {
+      withCheckbox: boolean;
+    }): Promise<void> {
+      // Заполняем все обязательные поля
+      fireEvent.change(screen.getByLabelText('Электронная почта'), {
+        target: { value: 'buyer@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('Телефон'), {
+        target: { value: '+79001112233' },
+      });
+      fireEvent.change(screen.getByLabelText('Имя'), { target: { value: 'Алексей' } });
+      fireEvent.change(screen.getByLabelText('Фамилия'), { target: { value: 'Смирнов' } });
+      fireEvent.change(screen.getByLabelText('Город'), { target: { value: 'Тверь' } });
+      fireEvent.change(screen.getByLabelText('Улица'), { target: { value: 'Советская' } });
+      fireEvent.change(screen.getByLabelText('Дом'), { target: { value: '7' } });
+      fireEvent.change(screen.getByLabelText('Почтовый индекс'), {
+        target: { value: '170000' },
+      });
+
+      // Способ доставки (radio)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Самовывоз/)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByLabelText(/Самовывоз/));
+
+      if (withCheckbox) {
+        await waitFor(() => {
+          expect(screen.getByTestId('save-address-checkbox-wrapper')).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByLabelText(/Запомнить этот адрес в профиле/));
+      }
+
+      const submitButton = screen.getByRole('button', { name: /оформить заказ/i });
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+    }
+
+    it('первый адрес у юзера — POST createAddress с is_default=true после успеха заказа', async () => {
+      const { useOrderStore } = await import('@/stores/orderStore');
+      const createOrder = vi.fn().mockResolvedValue(undefined);
+      (useOrderStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        createOrder,
+        isSubmitting: false,
+        error: null,
+        clearOrder: vi.fn(),
+      });
+      (
+        useOrderStore as unknown as { getState: ReturnType<typeof vi.fn> }
+      ).getState.mockReturnValue({
+        currentOrder: { id: 999 },
+        setError: vi.fn(),
+      });
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+      (addressService.createAddress as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeAddress({ id: 50 })
+      );
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        expect(addressService.getAddresses).toHaveBeenCalled();
+      });
+
+      await fillFormAndSubmit({ withCheckbox: true });
+
+      await waitFor(() => {
+        expect(createOrder).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(addressService.createAddress).toHaveBeenCalledWith(
+          expect.objectContaining({
+            address_type: 'shipping',
+            full_name: 'Алексей Смирнов',
+            phone: '+79001112233',
+            city: 'Тверь',
+            street: 'Советская',
+            building: '7',
+            postal_code: '170000',
+            is_default: true,
+          })
+        );
+      });
+    });
+
+    it('submit без чекбокса — createAddress не вызывается даже при ручном вводе', async () => {
+      const { useOrderStore } = await import('@/stores/orderStore');
+      const createOrder = vi.fn().mockResolvedValue(undefined);
+      (useOrderStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        createOrder,
+        isSubmitting: false,
+        error: null,
+        clearOrder: vi.fn(),
+      });
+      (
+        useOrderStore as unknown as { getState: ReturnType<typeof vi.fn> }
+      ).getState.mockReturnValue({
+        currentOrder: { id: 1000 },
+        setError: vi.fn(),
+      });
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+      render(<CheckoutForm user={mockUser} />);
+      await waitFor(() => {
+        expect(addressService.getAddresses).toHaveBeenCalled();
+      });
+
+      await fillFormAndSubmit({ withCheckbox: false });
+
+      await waitFor(() => {
+        expect(createOrder).toHaveBeenCalled();
+      });
+      expect(addressService.createAddress).not.toHaveBeenCalled();
+    });
+
+    it('гость — submit не вызывает createAddress даже при включённом чекбоксе (чекбокса нет)', async () => {
+      render(<CheckoutForm user={null} />);
+      // Чекбокс не должен существовать вообще
+      expect(screen.queryByTestId('save-address-checkbox-wrapper')).not.toBeInTheDocument();
+      expect(addressService.createAddress).not.toHaveBeenCalled();
+    });
+
+    it('адрес из селектора без правки — чекбокс «Запомнить» не показывается', async () => {
+      const list = [
+        makeAddress({ id: 1, is_default: true }),
+        makeAddress({ id: 2, full_name: 'Петя Петров' }),
+      ];
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce(list);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('address-card-option')).toHaveLength(2);
+      });
+
+      // Кликаем по второй карточке — поля заполняются, но юзер ничего не правил
+      fireEvent.click(screen.getAllByTestId('address-card-option')[1]);
+
+      // Чекбокса быть не должно (поля совпадают с выбранным адресом)
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('save-address-checkbox-wrapper')
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('2+ адресов без is_default — автозаполнен первый из массива', async () => {
+      const list = [
+        makeAddress({ id: 10, is_default: false, city: 'Сочи' }),
+        makeAddress({ id: 11, is_default: false, city: 'Казань' }),
+      ];
+      (addressService.getAddresses as ReturnType<typeof vi.fn>).mockResolvedValueOnce(list);
+
+      render(<CheckoutForm user={mockUser} />);
+
+      await waitFor(() => {
+        expect((screen.getByLabelText('Город') as HTMLInputElement).value).toBe('Сочи');
+      });
+      // Селектор должен быть виден (2 адреса)
+      expect(screen.getByTestId('address-selector')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/utils/checkout/addressMapping.ts
+++ b/frontend/src/utils/checkout/addressMapping.ts
@@ -1,0 +1,119 @@
+/**
+ * Маппинг адреса между API (snake_case) и формой checkout (camelCase).
+ *
+ * Единая точка трансформации: предотвращает рассинхронизацию полей,
+ * когда сторонние компоненты пытаются конвертировать данные ad-hoc.
+ *
+ * API поля   ↔ форма:
+ *   building          ↔ house
+ *   building_section  ↔ buildingSection
+ *   postal_code       ↔ postalCode
+ *   full_name         ↔ firstName + lastName (split по первому пробелу)
+ *   phone, city, street, apartment — без переименования
+ */
+
+import type { Address, AddressFormData } from '@/types/address';
+import type { CheckoutFormData } from '@/schemas/checkoutSchema';
+
+/**
+ * Поля формы, относящиеся к адресу + контактам, которые могут быть
+ * автозаполнены из сохранённого Address.
+ */
+export type CheckoutAddressFields = Pick<
+  CheckoutFormData,
+  | 'firstName'
+  | 'lastName'
+  | 'phone'
+  | 'city'
+  | 'street'
+  | 'house'
+  | 'buildingSection'
+  | 'apartment'
+  | 'postalCode'
+>;
+
+function splitFullName(
+  fullName: string | null | undefined
+): { firstName: string; lastName: string } {
+  if (!fullName) return { firstName: '', lastName: '' };
+  const trimmed = fullName.trim();
+  if (!trimmed) return { firstName: '', lastName: '' };
+  const spaceIdx = trimmed.indexOf(' ');
+  if (spaceIdx === -1) return { firstName: trimmed, lastName: '' };
+  return {
+    firstName: trimmed.slice(0, spaceIdx),
+    lastName: trimmed.slice(spaceIdx + 1).trim(),
+  };
+}
+
+/**
+ * Преобразует Address (ответ API) в значения полей формы checkout.
+ * Используется при автозаполнении формы выбранным сохранённым адресом.
+ */
+export function addressToFormValues(address: Address): CheckoutAddressFields {
+  const { firstName, lastName } = splitFullName(address.full_name);
+  return {
+    firstName,
+    lastName,
+    phone: address.phone,
+    city: address.city,
+    street: address.street,
+    house: address.building,
+    buildingSection: address.building_section ?? '',
+    apartment: address.apartment ?? '',
+    postalCode: address.postal_code,
+  };
+}
+
+/**
+ * Преобразует данные формы checkout в payload для POST /users/addresses/.
+ * Используется при сохранении нового адреса в профиль после оформления заказа.
+ *
+ * @param data - валидированные данные формы
+ * @param options.isDefault - флаг is_default для нового адреса
+ *   (true при отсутствии других адресов у пользователя — first save)
+ */
+export function formValuesToAddressPayload(
+  data: CheckoutFormData,
+  options: { isDefault: boolean }
+): AddressFormData {
+  return {
+    address_type: 'shipping',
+    full_name: `${data.firstName} ${data.lastName}`.trim(),
+    phone: data.phone,
+    city: data.city,
+    street: data.street,
+    building: data.house,
+    building_section: data.buildingSection ?? '',
+    apartment: data.apartment ?? '',
+    postal_code: data.postalCode,
+    is_default: options.isDefault,
+  };
+}
+
+/**
+ * Сравнивает поля формы со значениями из сохранённого адреса.
+ * Возвращает true, если хотя бы одно адресное поле формы отличается от
+ * соответствующего поля Address — то есть пользователь правил данные вручную
+ * после автозаполнения.
+ *
+ * Контактные поля (firstName/lastName/phone) тоже учитываются, поскольку
+ * Address их хранит.
+ */
+export function isFormDirtyVsAddress(
+  values: CheckoutAddressFields,
+  address: Address
+): boolean {
+  const expected = addressToFormValues(address);
+  return (
+    values.firstName !== expected.firstName ||
+    values.lastName !== expected.lastName ||
+    values.phone !== expected.phone ||
+    values.city !== expected.city ||
+    values.street !== expected.street ||
+    values.house !== expected.house ||
+    (values.buildingSection ?? '') !== expected.buildingSection ||
+    (values.apartment ?? '') !== expected.apartment ||
+    values.postalCode !== expected.postalCode
+  );
+}

--- a/frontend/src/utils/checkout/addressMapping.ts
+++ b/frontend/src/utils/checkout/addressMapping.ts
@@ -32,9 +32,10 @@ export type CheckoutAddressFields = Pick<
   | 'postalCode'
 >;
 
-function splitFullName(
-  fullName: string | null | undefined
-): { firstName: string; lastName: string } {
+function splitFullName(fullName: string | null | undefined): {
+  firstName: string;
+  lastName: string;
+} {
   if (!fullName) return { firstName: '', lastName: '' };
   const trimmed = fullName.trim();
   if (!trimmed) return { firstName: '', lastName: '' };
@@ -100,10 +101,7 @@ export function formValuesToAddressPayload(
  * Контактные поля (firstName/lastName/phone) тоже учитываются, поскольку
  * Address их хранит.
  */
-export function isFormDirtyVsAddress(
-  values: CheckoutAddressFields,
-  address: Address
-): boolean {
+export function isFormDirtyVsAddress(values: CheckoutAddressFields, address: Address): boolean {
   const expected = addressToFormValues(address);
   return (
     values.firstName !== expected.firstName ||


### PR DESCRIPTION
- Загрузка shipping-адресов через addressService.getAddresses() вместо мёртвого user.addresses[0] (API /users/me/ не возвращает адреса)
- Автозаполнение полей из адреса с is_default=true, fallback на первый
- Селектор карточек при 2+ сохранённых адресах (AddressCardOption)
- Чекбокс «Запомнить адрес в профиле» при ручном редактировании
- Fire-and-forget POST /users/addresses/ после успешного создания заказа
- Единый helper addressMapping.ts для маппинга API↔форма
- Защита от race conditions, privacy leak между сессиями, null-guard
- 48 тестов (27 CheckoutForm + 21 AddressSection), все зелёные