### PR TITLE
fix(deploy): webroot-метод для автообновления SSL-сертификата

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -151,6 +151,7 @@ services:
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ../data/prod/static:/var/www/static
       - ../data/prod/media:/var/www/media
+      - ../data/prod/certbot-webroot:/var/www/certbot
     ports:
       - "80:80"
       - "443:443"

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -4,7 +4,13 @@
 server {
     listen 80;
     server_name 5.35.124.149 localhost freesport.local freesport.ru www.freesport.ru;
-    
+
+    # Let's Encrypt ACME challenge (webroot метод для certbot renew без даунтайма)
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        allow all;
+    }
+
     # Redirect all HTTP traffic to HTTPS
     location / {
         return 301 https://$host$request_uri;


### PR DESCRIPTION
## Проблема

1С получала ошибку авторизации при проверке соединения с `https://freesport.ru/api/integration/1c/exchange/` — TLS handshake обрывался с `certificate expired`.

Корневая причина: SSL-сертификат freesport.ru истёк 2026-05-27. Systemd-таймер `certbot.timer` (renew дважды в день) использовал `authenticator=standalone`, требующий свободный порт 80. Порт занят Docker-контейнером nginx, поэтому автообновление молча падало ~1.5 месяца.

## Что сделано

- В `docker/nginx/conf.d/default.conf` добавлен `location /.well-known/acme-challenge/` (webroot-метод) в HTTP-server блок.
- В `docker/docker-compose.prod.yml` добавлен volume `../data/prod/certbot-webroot:/var/www/certbot` для сервиса nginx.
- На проде: создана директория `data/prod/certbot-webroot`, конфиг `/etc/letsencrypt/renewal/freesport.ru.conf` переключён на `authenticator = webroot`, сертификат обновлён вручную (действителен до 2026-10-06).

## Test plan

- [x] `certbot renew --dry-run` проходит успешно без остановки nginx
- [x] `curl https://freesport.ru/health` → 200
- [x] `curl http://freesport.ru/.well-known/acme-challenge/<file>` отдаёт файл через nginx
- [x] Запрос к `/api/integration/1c/exchange/` с неверным паролем возвращает 401 (сертификат валиден, запрос доходит до Django)
- [ ] Подтвердить в 1С успешную проверку соединения (пункт "Проверить соединение")

🤖 Generated with [Claude Code](https://claude.com/claude-code)