### PR TITLE
fix(integrations): закрыть race-condition в mode=import 1С-обмена

### DIFF
--- a/backend/apps/integrations/onec_exchange/import_orchestrator.py
+++ b/backend/apps/integrations/onec_exchange/import_orchestrator.py
@@ -309,8 +309,17 @@ class ImportOrchestratorService:
         file_type = self._detect_file_type()
         logger.info(f"[IMPORT] Dispatching Celery import task for " f"session_id={session.pk}, file_type={file_type}")
 
+        # Race-fix (same as _dispatch_or_dryrun): перевести session в IN_PROGRESS ДО
+        # dispatch. Иначе session остаётся PENDING в окне очереди Celery, и
+        # handle_init guard на другом потоке обмена не видит её как активную —
+        # cleanup_import_dir(force=True) стирает shared import dir раньше, чем
+        # воркер успевает обработать файл. process_1c_import_task сам повторно
+        # установит IN_PROGRESS на старте — операция идемпотентна.
+        from apps.products.models import ImportSession
+
+        session.status = ImportSession.ImportStatus.IN_PROGRESS
         session.report += f"[{timezone.now()}] Celery import task dispatched " f"(file_type={file_type})\n"
-        session.save(update_fields=["report", "updated_at"])
+        session.save(update_fields=["status", "report", "updated_at"])
 
         task_result = process_1c_import_task.delay(session.pk, str(self.import_dir))
 

--- a/backend/apps/integrations/tests/test_import_orchestration_view.py
+++ b/backend/apps/integrations/tests/test_import_orchestration_view.py
@@ -75,7 +75,10 @@ class TestICExchangeViewImport:
         assert ImportSession.objects.count() == 1
         session = ImportSession.objects.first()
         assert session is not None
-        assert session.status == ImportSession.ImportStatus.PENDING
+        # Race-fix: session marked IN_PROGRESS before Celery dispatch (see
+        # import_orchestrator.py::_dispatch_import) to guard shared import_dir
+        # from concurrent cleanup while still PENDING in the Celery queue.
+        assert session.status == ImportSession.ImportStatus.IN_PROGRESS
         assert "import.xml" in session.report
 
         # Verify task called

--- a/backend/apps/products/tests/integration/test_import_orchestration.py
+++ b/backend/apps/products/tests/integration/test_import_orchestration.py
@@ -82,7 +82,10 @@ class TestImportOrchestration:
             # Check session created
             session = ImportSession.objects.latest("created_at")
             assert session is not None
-            assert session.status == ImportSession.ImportStatus.PENDING
+            # Race-fix: session marked IN_PROGRESS before Celery dispatch (see
+            # import_orchestrator.py::_dispatch_import) to guard shared import_dir
+            # from concurrent cleanup while still PENDING in the Celery queue.
+            assert session.status == ImportSession.ImportStatus.IN_PROGRESS
             assert "test.xml" in session.report
 
             # Check task triggered

--- a/backend/tests/integration/test_onec_exchange_api.py
+++ b/backend/tests/integration/test_onec_exchange_api.py
@@ -376,7 +376,10 @@ class TestImportConcurrency:
 
         new_session = ImportSession.objects.exclude(pk=session.pk).first()
         assert new_session.session_key == sessid
-        assert new_session.status == ImportSession.ImportStatus.PENDING
+        # Race-fix: session marked IN_PROGRESS before Celery dispatch (see
+        # import_orchestrator.py::_dispatch_import) to guard shared import_dir
+        # from concurrent cleanup while still PENDING in the Celery queue.
+        assert new_session.status == ImportSession.ImportStatus.IN_PROGRESS
 
     def test_strict_session_linkage_url_priority(self):
         """


### PR DESCRIPTION
## Проблема

После обновления конфигуратора 1С и выгрузки справочников пользователь получил ошибки в сессиях импорта каталога товаров:

```
File not found: /app/var/onec/1c_import/offers/offers_1_2_....xml
File not found: /app/var/onec/1c_import/offers/offers_1_4_....xml
File not found: /app/var/onec/1c_import/offers/offers_1_6_....xml
```

## Причина

`import_dir` — общая (не изолированная по сессиям) директория. Есть guard в `handle_init`, который блокирует `cleanup_import_dir(force=True)`, если есть активные `IN_PROGRESS` `ImportSession`.

Для `mode=complete` (`_dispatch_or_dryrun`) уже есть race-fix: сессия помечается `IN_PROGRESS` **до** `process_1c_import_task.delay(...)`.

Для `mode=import` (`_dispatch_import`) этого фикса не было — сессия оставалась `PENDING` до момента, пока сам Celery-воркер не забирал задачу из очереди и не проставлял `IN_PROGRESS` (`tasks.py`). При перегруженной очереди (резкий рост объёма после обновления 1С) в этом окне параллельный поток обмена, вызвавший `mode=init`, не видел сессию как активную и стирал shared-директорию раньше, чем воркер успевал обработать файл.

## Фикс

`_dispatch_import` теперь помечает `session.status = IN_PROGRESS` до `.delay()`, зеркально `_dispatch_or_dryrun`.

## Test plan

- [x] `apps/integrations/tests/test_handle_init_cleanup_race.py` — 6/6 passed
- [x] `tests/integration/test_onec_import.py` — 15/15 passed
- [x] Black + Flake8 чисты
- [ ] Подтвердить в проде на следующей выгрузке из 1С, что ошибок `File not found` больше нет

🤖 Generated with [Claude Code](https://claude.com/claude-code)